### PR TITLE
Disable event head / face motion + Fix pick obj / Ice Stone despawn

### DIFF
--- a/CreamSA1/CreamSA1.vcxproj
+++ b/CreamSA1/CreamSA1.vcxproj
@@ -99,6 +99,7 @@
     <ClInclude Include="cheese.h" />
     <ClInclude Include="chrmodels.h" />
     <ClInclude Include="ears.h" />
+    <ClInclude Include="evhead.h" />
     <ClInclude Include="framework.h" />
     <ClInclude Include="GUI.h" />
     <ClInclude Include="mod.h" />
@@ -111,6 +112,7 @@
     <ClCompile Include="chrmodels.cpp" />
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="ears.cpp" />
+    <ClCompile Include="ev-head.cpp" />
     <ClCompile Include="GUI.cpp" />
     <ClCompile Include="mod.cpp" />
     <ClCompile Include="pch.cpp">

--- a/CreamSA1/CreamSA1.vcxproj.filters
+++ b/CreamSA1/CreamSA1.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClInclude Include="GUI.h">
       <Filter>Fichiers d%27en-tête</Filter>
     </ClInclude>
+    <ClInclude Include="evhead.h">
+      <Filter>Fichiers d%27en-tête</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -66,6 +69,9 @@
       <Filter>Fichiers sources</Filter>
     </ClCompile>
     <ClCompile Include="GUI.cpp">
+      <Filter>Fichiers sources</Filter>
+    </ClCompile>
+    <ClCompile Include="ev-head.cpp">
       <Filter>Fichiers sources</Filter>
     </ClCompile>
   </ItemGroup>

--- a/CreamSA1/cheese.cpp
+++ b/CreamSA1/cheese.cpp
@@ -39,7 +39,7 @@ static AnimationFile* CHEESE_FLY_ANM    = nullptr;
 static AnimationFile* CHEESE_ATTACK_ANM = nullptr;
 
 static NJS_ACTION CHEESE_ACTIONS[3] = {};
-static CCL_INFO CHEESE_CCL = { 0, CI_FORM_SPHERE, 0x40, 0x41, 0x400, { 0.0f, 1.5f, 0.0f }, 2.0f, 0.0f, 0.0f, 0.0f, 0, 0, 0 };
+static CCL_INFO CHEESE_CCL = { 0, CI_FORM_SPHERE, 0x40, 0x41, 0x400, { 0.0f, 1.5f, 0.0f }, 1.3f, 0.0f, 0.0f, 0.0f, 0, 0, 0 };
 static task* cheese_tp[8] = {};
 static int ComboTimers[8]{};
 
@@ -133,7 +133,7 @@ static void CheeseNormal(taskwk* twp, taskwk* ptwp, playerwk* ppwp)
 	}
 
 	// Offset from player
-	NJS_POINT3 v = { -1.5f + (0.25f * njCos(FrameCounterUnpaused * 80)), ppwp->p.height - 1.0f + (0.8f * njSin(FrameCounterUnpaused * 80)), 2.3f + (1.0f * njCos(FrameCounterUnpaused * 180)) };
+	NJS_POINT3 v = { -5.5f + (0.25f * njCos(FrameCounterUnpaused * 80)), ppwp->p.height - 1.0f + (0.8f * njSin(FrameCounterUnpaused * 80)), 2.3f + (1.0f * njCos(FrameCounterUnpaused * 180)) };
 
 	// Calc world position
 	njPushMatrix(_nj_unit_matrix_);
@@ -237,8 +237,7 @@ static void __cdecl CheeseExec(task* tp)
 	// Run animation
 	twp->value.f = fmod(twp->value.f + 1.0f, (float)(CHEESE_ACTIONS[twp->smode].motion->nbFrame - 1));
 	
-	if (GameState == 15)
-		EntryColliList(twp); // Add collision
+	EntryColliList(twp); // Add collision
 	LoopTaskC(tp); // Call the ball child task
 	tp->disp(tp); // Draw
 }
@@ -340,7 +339,7 @@ static void __declspec(naked) MilesChkMode_w()
 void InitCheese()
 {
 	MilesTalesPrower_t = new Trampoline(0x461700, 0x461707, MilesTalesPrower_r); // Hook Tails exec to add Cheese
-	MilesChkMode_t     = new Trampoline(0x45E5D0, 0x45E5D5, MilesChkMode_w); // Hook Tails modes to add custom attack
+	MilesChkMode_t = new Trampoline(0x45E5D0, 0x45E5D5, MilesChkMode_w); // Hook Tails modes to add custom attack
 
 	OpenModel(&CHEESE_MDL, "Cheese.sa1mdl");
 	OpenModel(&CHEESEBALL_MDL, "CheeseBall.sa1mdl");

--- a/CreamSA1/cheese.cpp
+++ b/CreamSA1/cheese.cpp
@@ -237,7 +237,8 @@ static void __cdecl CheeseExec(task* tp)
 	// Run animation
 	twp->value.f = fmod(twp->value.f + 1.0f, (float)(CHEESE_ACTIONS[twp->smode].motion->nbFrame - 1));
 	
-	EntryColliList(twp); // Add collision
+	if (GameState == 15)
+		EntryColliList(twp); // Add collision
 	LoopTaskC(tp); // Call the ball child task
 	tp->disp(tp); // Draw
 }

--- a/CreamSA1/cheese.cpp
+++ b/CreamSA1/cheese.cpp
@@ -5,6 +5,7 @@
 #include "AnimationFile.h"
 #include "utils.h"
 #include "pointers.h"
+#include "evhead.h"
 
 #define TWP_PNUM(twp) twp->counter.b[0]
 #define TWP_CHARA(twp) twp->counter.b[1]
@@ -255,11 +256,14 @@ static void CreateCheese(int pnum)
 static void __cdecl MilesTalesPrower_r(task* tp)
 {
 	auto twp = tp->twp;
+	auto co2 = (playerwk*)tp->mwp->work.l;
 
 	if (twp->mode == MILES_INIT)
 	{
 		CreateCheese(TWP_PNUM(twp));
 	}
+
+	DisableEV_HeadOnFrames(tp, twp, co2);
 
 	((decltype(MilesTalesPrower_r)*)MilesTalesPrower_t->Target())(tp);
 }

--- a/CreamSA1/ev-head.cpp
+++ b/CreamSA1/ev-head.cpp
@@ -1,0 +1,22 @@
+#include "pch.h"
+#include "pointers.h"
+
+void DisableEV_HeadOnFrames(task* obj, taskwk* data, playerwk* co2)
+{
+    if (data && data->ewp)
+    {
+        if (&data->ewp->face)
+        {
+            EV_ClrFace(obj);
+        }
+    }
+
+    if (co2 && co2->pfp)
+    {   
+        co2->pfp->frame = 0.0f;
+        co2->pfp->framespeed = 0.0f;
+        co2->pfp->face = 0;
+        co2->pfp->tblpoint = 0;
+        co2->pfp->tbl = 0;
+    }
+}

--- a/CreamSA1/evhead.h
+++ b/CreamSA1/evhead.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void DisableEV_HeadOnFrames(task* obj, taskwk* data, playerwk* co2);

--- a/CreamSA1/pointers.h
+++ b/CreamSA1/pointers.h
@@ -54,3 +54,17 @@ static inline BOOL MilesCheckInput(taskwk* twp, motionwk2* mwp, playerwk* pwp)
 	}
 	return result;
 }
+
+static const void* const MilesCheckHoldObjectPtr = (void*)0x45A9C0;
+static inline signed int MilesCheckHoldObj(playerwk* a1, taskwk* a2)
+{
+	int result;
+	__asm
+	{
+		mov esi, [a2]
+		mov edi, [a1]
+		call MilesCheckHoldObjectPtr
+		mov result, eax
+	}
+	return result;
+}

--- a/CreamSA1/pointers.h
+++ b/CreamSA1/pointers.h
@@ -10,6 +10,8 @@ static void(__cdecl** NodeCallbackFuncPtr)(NJS_OBJECT* obj) = (decltype(NodeCall
 
 FunctionPointer(float, Shadow, (taskwk* twp, float scl), 0x49EE30);
 
+TaskFunc(EV_ClrFace, 0x4310F0);
+
 static const void* const MilesChangeRunningMotionPtr = (void*)0x459DA0;
 static inline void MilesChangeRunningMotion(taskwk* twp, motionwk2* mwp, playerwk* pwp)
 {


### PR DESCRIPTION
* Updated submodules
* Disable event head and facemotion properly (this add compatibility for Super Tails and fix random Tails face showing up in cutscene)
* Fix IceStone despawn/Crash (there was an issue where after taking the train to mystic ruins the ice stone was simply gone, it was because of Cheese collision)
* Fix picking obj (again Cheese collision fault)